### PR TITLE
Add todo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all clean
 
 CC=cc
-CFLAGS=-g -O0 -Wall -pedantic -lglfw -lpthread -lGLEW -lGLU -lGL
+CFLAGS=-g -Og -march=native -Wall -pedantic -lglfw -fsanitize=address,undefined -lpthread -lGLEW -lGLU -lGL
 RM=rm
 
 all: test

--- a/load_shader.c
+++ b/load_shader.c
@@ -35,6 +35,7 @@ static const char *read_file_to_string(const char *file_path) {
       perror("realloc (vertex shader)");
       exit(EXIT_FAILURE);
     }
+    // TODO: Copy string with strcat
     strcpy(&read_file[read_file_size], read_line);
     read_file_size = new_length;
     free(read_line);


### PR DESCRIPTION
```
=18744==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x603000033b62 at pc 0x7f9c18096641 bp 0x7ffdb3dc66c0 sp 0x7ffdb3dc5e80
WRITE of size 19 at 0x603000033b62 thread T0
    #0 0x7f9c18096640 in __interceptor_strcpy.part.0 (/lib64/libasan.so.8+0x96640) (BuildId: 6f17f87dc4c1aa9f9dde7c4856604c3a25ba4872)
    #1 0x402be1 in read_file_to_string /home/maxi/repos/OpenGL-Testing/load_shader.c:38
    #2 0x402e33 in load_shaders /home/maxi/repos/OpenGL-Testing/load_shader.c:56
    #3 0x40280b in main /home/maxi/repos/OpenGL-Testing/test.c:63
    #4 0x7f9c17646149 in __libc_start_call_main (/lib64/libc.so.6+0x28149) (BuildId: 651b2bed7ecaf18098a63b8f10299821749766e6)
    #5 0x7f9c1764620a in __libc_start_main_impl (/lib64/libc.so.6+0x2820a) (BuildId: 651b2bed7ecaf18098a63b8f10299821749766e6)
    #6 0x402334 in _start (/home/maxi/repos/OpenGL-Testing/test+0x402334) (BuildId: 1fb2a5820ecbcdc084eb7f8b7632e844e2b0bb8d)

0x603000033b62 is located 0 bytes after 18-byte region [0x603000033b50,0x603000033b62)
allocated by thread T0 here:
    #0 0x7f9c180d81e5 in __interceptor_realloc.part.0 (/lib64/libasan.so.8+0xd81e5) (BuildId: 6f17f87dc4c1aa9f9dde7c4856604c3a25ba4872)
    #1 0x402c66 in read_file_to_string /home/maxi/repos/OpenGL-Testing/load_shader.c:34

SUMMARY: AddressSanitizer: heap-buffer-overflow (/lib64/libasan.so.8+0x96640) (BuildId: 6f17f87dc4c1aa9f9dde7c4856604c3a25ba4872) in __interceptor_strcpy.part.0
Shadow bytes around the buggy address:
  0x603000033880: 00 00 00 02 fa fa 00 00 00 02 fa fa 00 00 00 fa
  0x603000033900: fa fa 00 00 00 fa fa fa 00 00 00 05 fa fa 00 00
  0x603000033980: 06 fa fa fa 00 00 03 fa fa fa 00 00 03 fa fa fa
  0x603000033a00: 00 00 04 fa fa fa 00 00 00 02 fa fa 00 00 00 02
  0x603000033a80: fa fa 00 00 05 fa fa fa 00 00 05 fa fa fa 00 00
=>0x603000033b00: 02 fa fa fa 00 00 02 fa fa fa 00 00[02]fa fa fa
  0x603000033b80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x603000033c00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x603000033c80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x603000033d00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x603000033d80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==18744==ABORTING
```